### PR TITLE
Restore previous callaudiod behaviour

### DIFF
--- a/pinephone-callaudiod
+++ b/pinephone-callaudiod
@@ -129,7 +129,7 @@ class Mode(enum.Enum):
 
 class Speaker(enum.Enum):
 	DEFAULT = enum.auto()
-	FORCED = enum.auto()
+	DISABLED = enum.auto()
 
 class Mic(enum.Enum):
 	MUTED = enum.auto()
@@ -154,13 +154,13 @@ def select(mode: Mode) -> None:
 
 	match choice.speaker:
 		case Speaker.DEFAULT:
-			for profile_suffix in ('Headphones, Headset', 'Headphones, Mic', 'Earpiece, Mic'):
+			for profile_suffix in ('Headphones, Headset', 'Headphones, Mic', 'Headset, Speaker', 'Mic, Speaker'):
 				if f'{profile_name} ({profile_suffix})' in available_profiles:
 					profile_name = f'{profile_name} ({profile_suffix})'
 					found_profile = True
 					break
-		case Speaker.FORCED:
-			for profile_suffix in ('Headset, Speaker', 'Mic, Speaker'):
+		case Speaker.DISABLED:
+			for profile_suffix in ('Headphones, Headset', 'Headphones, Mic', 'Earpiece, Headset', 'Earpiece, Mic'):
 				if f'{profile_name} ({profile_suffix})' in available_profiles:
 					profile_name = f'{profile_name} ({profile_suffix})'
 					found_profile = True
@@ -266,9 +266,9 @@ class CallAudiod:
 
 	def EnableSpeaker(self, enable: dasbus.typing.Bool) -> dasbus.typing.Bool:
 		if enable:
-			speaker = Speaker.FORCED
-		else:
 			speaker = Speaker.DEFAULT
+		else:
+			speaker = Speaker.DISABLED
 
 		match self.__mode:
 			case Mode.DEFAULT:
@@ -315,10 +315,10 @@ class CallAudiod:
 
 		match choice.speaker:
 			case Speaker.DEFAULT:
-				return DbusAPI.CALL_AUDIO_SPEAKER_OFF
-
-			case Speaker.FORCED:
 				return DbusAPI.CALL_AUDIO_SPEAKER_ON
+
+			case Speaker.DISABLED:
+				return DbusAPI.CALL_AUDIO_SPEAKER_OFF
 
 	@property
 	def MicState(self) -> DbusAPI.MicState:


### PR DESCRIPTION
Before upgrading pmOS past Pipewire 1.0.6 and having Mobian's callaudiod installed, the speaker was on by default and would allow switching to headphones seamlessly, and only switch to the earpiece during calls. Current behaviour has the earpiece as the default audio provider, and manually enabling the speaker (callaudiocli -s 1) will completely disable headphone output unless the speaker is disabled again. This commit just re-enables the speaker default behaviour, while still allowing switching to headphones when plugged in and the earpiece in calls.

Tests done so far:
- Called pinephone - Switches to earpiece and uses mic, switches back to speaker once ended (speaker sometimes switches back muted?).
- Called pinephone with headphones in - Uses headset mic and headphone output, only switch is from HiFi mode to call mode. Have to be careful with having muted output before a call however, as the HiFi->call profile switch does not unmute the headphones for you.
- Called pinephone with headphones in, unplug headphones during call - Switches from headphone/headset to earpiece/mic once unplugged, then to speaker output once call ends.
- Called pinephone, then plugged headphones in during call - Switches from earpiece/mic to headphone/headset.